### PR TITLE
Fix jagged edges on iOS

### DIFF
--- a/assets/scss/_profile.scss
+++ b/assets/scss/_profile.scss
@@ -284,6 +284,10 @@
           right: -15px;
           top: -20px;
           border: none;
+
+          /* antialiasing */
+          outline: 1px solid transparent;
+          will-change: transform;
         }
       }
 


### PR DESCRIPTION
:mag: The image rotation produced jagged edges on iOS devices (only reproducible on Simulator or real hardware).

Manually activating optimizations with `will-change` and adding a transparent border smoothes out the edges.
